### PR TITLE
Improve manifest metadata

### DIFF
--- a/custom_components/mqtt_relay_cover/manifest.json
+++ b/custom_components/mqtt_relay_cover/manifest.json
@@ -9,11 +9,15 @@
         "mqtt"
     ],
     "documentation": "https://github.com/bpopovych/mqtt_relay_cover",
+    "issue_tracker": "https://github.com/bpopovych/mqtt_relay_cover/issues",
+    "quality_scale": "custom",
+    "integration_type": "hub",
     "homekit": {},
-    "iot_class": "local_push",
+    "iot_class": "assumed_state",
+    "single_config_entry": true,
     "requirements": [],
     "ssdp": [],
-    "version": "0.1.0",
+    "version": "0.2.0",
     "zeroconf": [],
     "loggers": [
         "custom_components.mqtt_relay_cover"


### PR DESCRIPTION
## Summary
- set manifest quality to `custom`
- mark the integration as a hub
- indicate assumed state and single config entry
- bump version to 0.2.0

## Testing
- `pytest -q`
