### PR TITLE
Add config flow

### DIFF
--- a/custom_components/mqtt_relay_cover/__init__.py
+++ b/custom_components/mqtt_relay_cover/__init__.py
@@ -1,1 +1,24 @@
 """MQTT Relay Cover Control integration."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.const import Platform
+
+from .const import DOMAIN
+
+PLATFORMS: list[Platform] = [Platform.COVER]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up MQTT Relay Cover from a config entry."""
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/custom_components/mqtt_relay_cover/config_flow.py
+++ b/custom_components/mqtt_relay_cover/config_flow.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+
+from .const import (
+    DOMAIN,
+    CONF_OPENING_TIME,
+    CONF_CLOSING_TIME,
+    CONF_MQTT_COMMAND_TOPIC,
+    CONF_MQTT_PAYLOAD_OPEN,
+    CONF_MQTT_PAYLOAD_CLOSE,
+    CONF_MQTT_PAYLOAD_STOP,
+)
+
+
+class MQTTRelayCoverConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for MQTT Relay Cover."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, any] | None = None):
+        """Handle the initial step."""
+        if user_input is not None:
+            return self.async_create_entry(title=user_input.get("name", "MQTT Relay Cover"), data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required("name", default="MQTT Relay Cover"): str,
+                vol.Required(CONF_OPENING_TIME): vol.Coerce(int),
+                vol.Optional(CONF_CLOSING_TIME): vol.Coerce(int),
+                vol.Required(CONF_MQTT_COMMAND_TOPIC): str,
+                vol.Required(CONF_MQTT_PAYLOAD_OPEN): str,
+                vol.Required(CONF_MQTT_PAYLOAD_CLOSE): str,
+                vol.Required(CONF_MQTT_PAYLOAD_STOP): str,
+            }
+        )
+
+        return self.async_show_form(step_id="user", data_schema=data_schema)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: config_entries.ConfigEntry):
+        return MQTTRelayCoverOptionsFlow(config_entry)
+
+
+class MQTTRelayCoverOptionsFlow(config_entries.OptionsFlow):
+    """Handle options flow for MQTT Relay Cover."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input: dict[str, any] | None = None):
+        """Manage the options for the custom component."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required("name", default=self.config_entry.data.get("name", "MQTT Relay Cover")): str,
+                vol.Required(CONF_OPENING_TIME, default=self.config_entry.data.get(CONF_OPENING_TIME, 0)): vol.Coerce(int),
+                vol.Optional(
+                    CONF_CLOSING_TIME,
+                    default=self.config_entry.data.get(CONF_CLOSING_TIME, self.config_entry.data.get(CONF_OPENING_TIME, 0)),
+                ): vol.Coerce(int),
+                vol.Required(
+                    CONF_MQTT_COMMAND_TOPIC,
+                    default=self.config_entry.data.get(CONF_MQTT_COMMAND_TOPIC, ""),
+                ): str,
+                vol.Required(
+                    CONF_MQTT_PAYLOAD_OPEN,
+                    default=self.config_entry.data.get(CONF_MQTT_PAYLOAD_OPEN, ""),
+                ): str,
+                vol.Required(
+                    CONF_MQTT_PAYLOAD_CLOSE,
+                    default=self.config_entry.data.get(CONF_MQTT_PAYLOAD_CLOSE, ""),
+                ): str,
+                vol.Required(
+                    CONF_MQTT_PAYLOAD_STOP,
+                    default=self.config_entry.data.get(CONF_MQTT_PAYLOAD_STOP, ""),
+                ): str,
+            }
+        )
+
+        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/mqtt_relay_cover/cover.py
+++ b/custom_components/mqtt_relay_cover/cover.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -54,7 +55,7 @@ async def async_setup_platform(
     config: ConfigType,
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
-) -> None:
+    ) -> None:
     """Set up the MQTT Relay Cover.
 
     This function is responsible for setting up the MQTT Relay Cover component.
@@ -75,3 +76,10 @@ async def async_setup_platform(
             if not _LOGGER.info("Setting MQTT Relay Cover: %s", object_id)
         ]
     )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up MQTT Relay Cover from a config entry."""
+    async_add_entities([MQTTRelayCover(entry.entry_id, entry.data)])

--- a/custom_components/mqtt_relay_cover/manifest.json
+++ b/custom_components/mqtt_relay_cover/manifest.json
@@ -4,7 +4,7 @@
     "codeowners": [
         "@bpopovych"
     ],
-    "config_flow": false,
+    "config_flow": true,
     "dependencies": [
         "mqtt"
     ],


### PR DESCRIPTION
## Summary
- enable config flow support in manifest
- add HA config entry setup and forward to cover platform
- expose `async_setup_entry` in cover platform
- implement a config flow/option flow for UI configuration
- use Platform constant

## Testing
- `python -m py_compile custom_components/mqtt_relay_cover/*.py`
- `pytest -q`
